### PR TITLE
Upgrade forward+ renderer and remove compatibility setting

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -16,5 +16,4 @@ config/features=PackedStringArray("4.4")
 
 [rendering]
 
-renderer/rendering_method="gl_compatibility"
 quality/driver/driver_name="GLES3"


### PR DESCRIPTION
Someone started the project with the compatibility renderer and I think we have no legacy reason to do that. So I changed the setting as shown on the screenshot. It makes sense to keep it on the modern setting until we run into specific issues

![image](https://github.com/user-attachments/assets/7f84d750-444f-4fe3-b2a4-da2547415988)
